### PR TITLE
Don't alter an existing control digit, even if its wrong

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,11 @@
 PATH
   remote: .
   specs:
-    personnummer (0.0.3)
+    personnummer (0.0.6)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    archive-tar-minitar (0.5.2)
-    columnize (0.3.4)
     configatron (2.8.3)
       yamler (>= 0.1.0)
     cover_me (1.2.0)
@@ -22,8 +20,7 @@ GEM
     guard-rspec (0.4.5)
       guard (>= 0.4.0)
     hashie (1.1.0)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
+    rake (0.9.2.2)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -32,16 +29,6 @@ GEM
     rspec-expectations (2.7.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.7.0)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     thor (0.14.6)
     timecop (0.3.5)
     yamler (0.1.0)
@@ -55,6 +42,6 @@ DEPENDENCIES
   guard-bundler
   guard-rspec
   personnummer!
+  rake
   rspec
-  ruby-debug19
   timecop

--- a/lib/personnummer.rb
+++ b/lib/personnummer.rb
@@ -13,7 +13,10 @@ class Personnummer
     if number.match(/(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\-\+]{0,1})(\d{3})(\d{0,1})/)
 
       # Calculate the control digit based on the birth date and serial number
-      @control_digit = luhn_algorithm("#{$~[2]}#{$~[3]}#{$~[4]}#{$~[6]}")
+      cd = luhn_algorithm("#{$~[2]}#{$~[3]}#{$~[4]}#{$~[6]}")
+
+      # Set control digit to calculated if it's missing
+      @control_digit = $~[7].blank? ? cd : $~[7].to_i
 
       # Get the different parts of the number
       century  = $~[1].to_i
@@ -29,7 +32,7 @@ class Personnummer
       end
 
       # Make the personnummer valid if the checksum is correct
-      @valid = true if @control_digit == $~[7].to_i && !$~[7].empty?
+      @valid = true if @control_digit == cd && !$~[7].empty?
 
       # Get the current date
       today = Date.today

--- a/spec/lib/personnummer_spec.rb
+++ b/spec/lib/personnummer_spec.rb
@@ -104,6 +104,11 @@ describe Personnummer do
       Personnummer.new('900101-0017').control_digit.should == 7
       Personnummer.new('900101-001').control_digit.should == 7
     end
+
+    it "should not alter existing control digit" do
+      pnr = "901010-0010"
+      Personnummer.new(pnr).to_s.should == pnr
+    end
   end
 
   describe "to_s" do


### PR DESCRIPTION
I don't think that the gem should rectify erroneous control digits, only add it if its missing

What do you think?

BR
/Sebastian
